### PR TITLE
Disable prefetching for leaderboards page

### DIFF
--- a/app/api/hello/route.ts
+++ b/app/api/hello/route.ts
@@ -8,27 +8,27 @@ const text = `Exercitation aliquip aliqua esse sint consectetur tempor aute eius
 
 const encoder = new TextEncoder();
 
-async function* makeIterator() {
-  yield encoder.encode("One ");
-  await sleep(200);
-  yield encoder.encode("Two ");
-  await sleep(200);
-  yield encoder.encode("Three");
+async function* countFrom(n: number) {
+  for (let i = n; i < Infinity; i++) {
+    await sleep(500);
+    yield encoder.encode(`${text} + ${i}`);
+  }
 }
 
 export const runtime = "edge";
 
 export async function GET() {
-  let start = 0;
-  let enqueued = 0;
   const body = new ReadableStream<Uint8Array>({
     pull: async controller => {
-      let sliceNum = 0;
-      if (enqueued >= text.length) controller.close();
-      enqueued += 10;
-      sliceNum += 10;
-      await sleep(500);
-      controller.enqueue(encoder.encode(text.slice(0, sliceNum)));
+      let iterations = 0;
+      for await (const value of countFrom(1)) {
+        if (iterations === 200) {
+          controller.close();
+          break;
+        }
+        iterations++;
+        controller.enqueue(value);
+      }
     }
   });
   return new Response(body);

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -15,7 +15,9 @@ export function Navbar() {
               <NavLink href="/quiz">Quiz</NavLink>
             </li>
             <li className="">
-              <NavLink href="/leaderboards">Leaderboards</NavLink>
+              <NavLink hardNav href="/leaderboards">
+                Leaderboards
+              </NavLink>
             </li>
           </ul>
         </nav>

--- a/components/NavLink.tsx
+++ b/components/NavLink.tsx
@@ -5,12 +5,14 @@ import { usePathname } from "next/navigation";
 type PropTypes = {
   href: string;
   children: React.ReactNode;
+  hardNav?: boolean;
 };
 
-export function NavLink({ href, children }: PropTypes) {
+export function NavLink({ href, children, hardNav }: PropTypes) {
   const path = usePathname();
   return (
     <Link
+      prefetch={!hardNav}
       href={href}
       className={`h-full relative   w-full duration-200 ease-out 
       flex flex-col items-center justify-center ${


### PR DESCRIPTION
This will ensure that the leaderboards page always fetches data on every page request.